### PR TITLE
Pass `value_changed` to `macro_rules!` macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "anyhow"
-version = "1.0.28"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
+checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
 name = "anymap"
@@ -42,9 +42,9 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bumpalo"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
+checksum = "5356f1d23ee24a1f785a56d1d1a5f0fd5b0f6a0c0fb2412ce11da71649ab78f6"
 
 [[package]]
 name = "byteorder"
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "fnv"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "http"
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
+checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro-nested"
@@ -139,18 +139,18 @@ checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
+checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
+checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 dependencies = [
  "proc-macro2",
 ]
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "semver"
@@ -187,18 +187,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.106"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
+checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.106"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
+checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
+checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
 dependencies = [
  "itoa",
  "ryu",
@@ -281,9 +281,9 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "syn"
-version = "1.0.18"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
+checksum = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -292,18 +292,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.16"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12a1dae4add0f0d568eebc7bf142f145ba1aa2544cafb195c76f0f409091b60"
+checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.16"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
+checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -318,9 +318,9 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.62"
+version = "0.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
+checksum = "4c2dc4aa152834bc334f506c1a06b866416a8b6697d5c9f75b9a689c8486def0"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.62"
+version = "0.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3972e137ebf830900db522d6c8fd74d1900dcfc733462e9a12e942b00b4ac94"
+checksum = "ded84f06e0ed21499f6184df0e0cb3494727b0c5da89534e0fcc55c51d812101"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.62"
+version = "0.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
+checksum = "838e423688dac18d73e31edce74ddfac468e37b1506ad163ffaf0a46f703ffe3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.62"
+version = "0.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
+checksum = "3156052d8ec77142051a533cdd686cba889537b213f948cd1d20869926e68e92"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.62"
+version = "0.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91c2916119c17a8e316507afaaa2dd94b47646048014bbdf6bef098c1bb58ad"
+checksum = "c9ba19973a58daf4db6f352eda73dc0e289493cd29fb2632eb172085b6521acd"
 
 [[package]]
 name = "yew"

--- a/src/color.rs
+++ b/src/color.rs
@@ -60,7 +60,7 @@ impl Component for ColorPicker {
 
 #[macro_export]
 macro_rules! color {
-    ( $name:expr, $value:expr ) => {
-        html!(<ColorPicker name=$name value=&mut $value as *mut String value_changed=value_changed.clone() />)
+    ( $name:expr, $value:expr, $value_changed:expr) => {
+        html!(<ColorPicker name=$name value=&mut $value as *mut String value_changed=$value_changed.clone() />)
     };
 }

--- a/src/parts/eyes.rs
+++ b/src/parts/eyes.rs
@@ -18,14 +18,14 @@ impl Eyes {
     pub fn controls(&mut self, value_changed: Callback<()>) -> Html {
         html!(
             <Group name="Eyes">
-                {crate::color!("Color", self.color)}
-                {crate::slider!("Width", 0.0, 6.0, self.size.0)}
-                {crate::slider!("Height", 0.0, 3.0, self.size.1)}
-                {crate::slider!("Separation", 0.0, 6.0, self.separation)}
+                {crate::color!("Color", self.color, value_changed)}
+                {crate::slider!("Width", 0.0, 6.0, self.size.0, value_changed)}
+                {crate::slider!("Height", 0.0, 3.0, self.size.1, value_changed)}
+                {crate::slider!("Separation", 0.0, 6.0, self.separation, value_changed)}
                 <Group name="Brows">
-                    {crate::slider!("B1", 0.0, 2.0, self.brows.end_height.0)}
-                    {crate::slider!("B2", 0.0, 2.0, self.brows.curve)}
-                    {crate::slider!("B3", 0.0, 2.0, self.brows.end_height.1)}
+                    {crate::slider!("B1", 0.0, 2.0, self.brows.end_height.0, value_changed)}
+                    {crate::slider!("B2", 0.0, 2.0, self.brows.curve, value_changed)}
+                    {crate::slider!("B3", 0.0, 2.0, self.brows.end_height.1, value_changed)}
                 </Group>
             </Group>
         )

--- a/src/parts/face.rs
+++ b/src/parts/face.rs
@@ -36,8 +36,8 @@ impl Forehead {
     pub fn controls(&mut self, value_changed: Callback<()>) -> Html {
         html!(
             <Group name="Forehead">
-                {crate::slider!("RX", 0.0, 7.0, self.roundness.0)}
-                {crate::slider!("RY", 0.0, 10.0, self.roundness.1)}
+                {crate::slider!("RX", 0.0, 7.0, self.roundness.0, value_changed)}
+                {crate::slider!("RY", 0.0, 10.0, self.roundness.1, value_changed)}
             </Group>
         )
     }
@@ -53,10 +53,10 @@ impl Fringe {
     pub fn controls(&mut self, value_changed: Callback<()>) -> Html {
         html!(
             <Group name="Fringe">
-                {crate::color!("Color", self.hair_color)}
-                {crate::slider!("Thickness", 0.0, 10.0, self.thickness)}
-                {crate::slider!("RX", 0.0, 7.0, self.roundness.0)}
-                {crate::slider!("RY", 0.0, 10.0, self.roundness.1)}
+                {crate::color!("Color", self.hair_color, value_changed)}
+                {crate::slider!("Thickness", 0.0, 10.0, self.thickness, value_changed)}
+                {crate::slider!("RX", 0.0, 7.0, self.roundness.0, value_changed)}
+                {crate::slider!("RY", 0.0, 10.0, self.roundness.1, value_changed)}
             </Group>
         )
     }
@@ -70,8 +70,8 @@ impl Chin {
     pub fn controls(&mut self, value_changed: Callback<()>) -> Html {
         html!(
             <Group name="Chin">
-                {crate::slider!("RX", 0.0, 7.0, self.roundness.0)}
-                {crate::slider!("RY", 0.0, 10.0, self.roundness.1)}
+                {crate::slider!("RX", 0.0, 7.0, self.roundness.0, value_changed)}
+                {crate::slider!("RY", 0.0, 10.0, self.roundness.1, value_changed)}
             </Group>
         )
     }
@@ -90,9 +90,9 @@ impl Face {
     pub fn controls(&mut self, value_changed: Callback<()>) -> Html {
         html!(
             <Group name="Face">
-                {crate::color!("Skin", self.skin_color)}
-                {crate::slider!("Width", 0.0, 16.0, self.width)}
-                {crate::slider!("Height", 0.0, 32.0, self.height)}
+                {crate::color!("Skin", self.skin_color, value_changed)}
+                {crate::slider!("Width", 0.0, 16.0, self.width, value_changed)}
+                {crate::slider!("Height", 0.0, 32.0, self.height, value_changed)}
                 {self.forehead.controls(value_changed.clone())}
                 {self.fringe.controls(value_changed.clone())}
                 {self.chin.controls(value_changed.clone())}

--- a/src/parts/mod.rs
+++ b/src/parts/mod.rs
@@ -53,7 +53,7 @@ impl ScaledHead {
         html!(
             <>
                 <Group name="Grid">
-                    {crate::slider!("Size", 8.0, 32.0, self.scale)}
+                    {crate::slider!("Size", 8.0, 32.0, self.scale, value_changed)}
                 </Group>
                 {self.head.controls(value_changed.clone())}
             </>

--- a/src/parts/mouth.rs
+++ b/src/parts/mouth.rs
@@ -11,11 +11,11 @@ impl TopLip {
     pub fn controls(&mut self, value_changed: Callback<()>) -> Html {
         html!(
             <Group name="Top Lip">
-                {crate::slider!("RX", 0.0, 2.0, self.roundness.0)}
-                {crate::slider!("RY", 0.0, 2.0, self.roundness.1)}
+                {crate::slider!("RX", 0.0, 2.0, self.roundness.0, value_changed)}
+                {crate::slider!("RY", 0.0, 2.0, self.roundness.1, value_changed)}
                 <Group name="Philtrum">
-                    {crate::slider!("Width", 0.0, 1.0, self.philtrum.0)}
-                    {crate::slider!("Position", 0.0, 1.0, self.philtrum.1)}
+                    {crate::slider!("Width", 0.0, 1.0, self.philtrum.0, value_changed)}
+                    {crate::slider!("Position", 0.0, 1.0, self.philtrum.1, value_changed)}
                 </Group>
             </Group>
         )
@@ -30,8 +30,8 @@ impl BottomLip {
     pub fn controls(&mut self, value_changed: Callback<()>) -> Html {
         html!(
             <Group name="Bottom Lip">
-                {crate::slider!("RX", 0.0, 2.0, self.roundness.0)}
-                {crate::slider!("RY", 0.0, 2.0, self.roundness.1)}
+                {crate::slider!("RX", 0.0, 2.0, self.roundness.0, value_changed)}
+                {crate::slider!("RY", 0.0, 2.0, self.roundness.1, value_changed)}
             </Group>
         )
     }
@@ -50,12 +50,12 @@ impl Mouth {
     pub fn controls(&mut self, value_changed: Callback<()>) -> Html {
         html!(
             <Group name="Mouth">
-                {crate::color!("Color", self.color)}
+                {crate::color!("Color", self.color, value_changed)}
                 {self.top_lip.controls(value_changed.clone())}
                 {self.bottom_lip.controls(value_changed.clone())}
                 <Group name="Smile">
-                    {crate::slider!("Width", 0.0, 2.0, self.smile.0)}
-                    {crate::slider!("Height", 0.0, 2.0, self.smile.1)}
+                    {crate::slider!("Width", 0.0, 2.0, self.smile.0, value_changed)}
+                    {crate::slider!("Height", 0.0, 2.0, self.smile.1, value_changed)}
                 </Group>
             </Group>
         )

--- a/src/parts/nose.rs
+++ b/src/parts/nose.rs
@@ -16,23 +16,23 @@ impl Nose {
     pub fn controls(&mut self, value_changed: Callback<()>) -> Html {
         html!(
             <Group name="Nose">
-                {crate::slider!("Width", 0.0, 4.0, self.width)}
-                {crate::slider!("Height", 0.0, 5.0, self.height)}
+                {crate::slider!("Width", 0.0, 4.0, self.width, value_changed)}
+                {crate::slider!("Height", 0.0, 5.0, self.height, value_changed)}
                 <Group name="Bridge">
                     <Group name="Gap">
-                        {crate::slider!("X", 0.0, 2.0, self.bridge_gap.0)}
-                        {crate::slider!("Y", 0.0, 2.0, self.bridge_gap.1)}
+                        {crate::slider!("X", 0.0, 2.0, self.bridge_gap.0, value_changed)}
+                        {crate::slider!("Y", 0.0, 2.0, self.bridge_gap.1, value_changed)}
                     </Group>
                     <Group name="Top Curve">
-                        {crate::slider!("X", 0.0, 4.0, self.bridge_top_curve.0)}
-                        {crate::slider!("Y", 0.0, 4.0, self.bridge_top_curve.1)}
+                        {crate::slider!("X", 0.0, 4.0, self.bridge_top_curve.0, value_changed)}
+                        {crate::slider!("Y", 0.0, 4.0, self.bridge_top_curve.1, value_changed)}
                     </Group>
                     <Group name="Side Curve">
-                        {crate::slider!("X", 0.0, 1.0, self.bridge_side_curve.0)}
-                        {crate::slider!("Y", 0.0, 1.0, self.bridge_side_curve.1)}
+                        {crate::slider!("X", 0.0, 1.0, self.bridge_side_curve.0, value_changed)}
+                        {crate::slider!("Y", 0.0, 1.0, self.bridge_side_curve.1, value_changed)}
                     </Group>
-                    {crate::slider!("Nostril", 0.0, 0.5, self.nostril_radius)}
-                    {crate::slider!("Tip", 0.0, 0.5, self.tip_curve)}
+                    {crate::slider!("Nostril", 0.0, 0.5, self.nostril_radius, value_changed)}
+                    {crate::slider!("Tip", 0.0, 0.5, self.tip_curve, value_changed)}
                 </Group>
             </Group>
         )

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -98,7 +98,7 @@ impl Component for Slider {
 
 #[macro_export]
 macro_rules! slider {
-    ( $name:expr, $min:expr, $max:expr, $value:expr ) => {
-        html!(<Slider name=$name min=$min max=$max value=&mut $value as *mut Value value_changed=value_changed.clone() />)
+    ( $name:expr, $min:expr, $max:expr, $value:expr, $value_changed:ident ) => {
+        html!(<Slider name=$name min=$min max=$max value=&mut $value as *mut Value value_changed=$value_changed.clone() />)
     };
 }


### PR DESCRIPTION
In Rust, variable identifiers in a `macro_rules!` body are resolved
in the scope of tht body - they cannot see through to the caller's body.
For example, the following code errors:

```rust
macro_rules! weird_ident {
    () => { my_ident; }
}

fn main() {
    let my_ident = 1;
    weird_ident!();
}
```

However, due to a compiler bug (rust-lang/rust#43081),
this kind of code current compiles when a procedural macro is invoked by
a `macro_rules!` macro. Eventually, this will cause a compilation error.

In the `color!` and `slider!` macro, you're currently writing an expression
involving `value_changed`, and passing it to a procedural macro (`html!`).
However, `value_changed` comes from the body of the caller of `color!`/`slider!`,
so this code will stop compiling once the compiler bug is fixed.

Fortunately, the identifier of `value_changed` can be passed into
`color!` and `slider!`. This modified code will with the current version of
Rust, as well as future version that causes the old code into an error.

I also ran `cargo update` to bump the dependencies in your Cargo.lock.
This will allow your crate to continue to compile when the compiler bug is fixed,
as you are depending on some crates (e.g. `syn`) that have released updates
to address the issue.

Feel free to ask me about any questions you may have. For more details,
see rust-lang/rust#72622